### PR TITLE
If there are any writeable sockets, even if there's nothing to send, …

### DIFF
--- a/server.py
+++ b/server.py
@@ -12,6 +12,7 @@ import struct
 from threading import Thread, Lock
 from Queue import Queue
 from functools import wraps
+from time import sleep
 protocol="SSL v 23"
 
 #use the higuest available ssl protocol version
@@ -235,6 +236,7 @@ class Channel(baseServer):
 		self.checkThread.start()
 		while self.running and len(self.clients.values())>0:
 			try:
+				sleep(0.01) # Prevent 100% cpu usage when there's at least one writeable socket
 				r, w, e = select.select(self.client_sockets, self.client_sockets, self.client_sockets, 60)
 			except:
 				printError()


### PR DESCRIPTION
…server gets into 100% hard loop.

The problem is that doing a "readable" and "error" select on each connected client is just fine ... that will have the expected behavior of waiting until there's something to do (or until the timeout occurs).

BUT...doing a "writeable" select on all connected clients is a problem, since these sockets are usually writeable (unless they're clogged).  So the server gets into a hard loop in which it uses 100% of available cpu.  

SImply putting a sleep of even 10ms into the loop reduces this from 100% to just a few percent, which is far better-behaved -- but at the same time, a 10ms delay isn't going to be noticable.

The *correct* approach, of course, is to filter the list of sockets to only those for which there is pending data to send out -- but that's difficult (and also because it's hard to know when during the 60-second timeout there isn't suddenly more data to send.  So I think that this kludge is the minimally-invasive approach to reducing this 100% cpu problem.  Thank you!

Marshall