### PR TITLE
Set PID file to the default path in the systemd service

### DIFF
--- a/debian8/nvda-remote-server_1.8/lib/systemd/system/NVDARemoteServer.service
+++ b/debian8/nvda-remote-server_1.8/lib/systemd/system/NVDARemoteServer.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User=nvdaremoteserver
 Type=forking
-PIDFile=/var/run/NVDARemoteServer/NVDARemoteServer.pid
+PIDFile=/var/run/NVDARemoteServer.pid
 ExecStart=/usr/bin/python /usr/share/NVDARemoteServer/server.py start
 ExecStop=/usr/bin/python /usr/share/NVDARemoteServer/server.py stop
 ExecReload=/usr/bin/python /usr/share/NVDARemoteServer/server.py restart


### PR DESCRIPTION
Since version 1.8, the systemd service refuses to start because of the default PID file path is different than this in the systemd unit file.
This pull request changes the path in the NVDARemoteServer.service file.