### PR TITLE
Display warning before any user defined message of the day.

### DIFF
--- a/options.py
+++ b/options.py
@@ -57,7 +57,7 @@ def setup():
 	if loglevel > 3:
 		if motd is None:
 			motd = ""
-		motd = motd + " Warning! This server is running with the maximum allowed log level. All your activity is being recorded inside a log file."
+		motd = "Warning! This server is running with the maximum allowed log level. All your activity is being recorded inside a log file. " + motd
 		motd_force_display = True
 
 


### PR DESCRIPTION
If the warning is displayed last, it might be missed. It's more prominent if it's displayed before any user defined message of the day.